### PR TITLE
feat: add admin setting to enable/disable anonymous posting (#9)

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -154,6 +154,7 @@
     "hideEmail": 0,
     "showFullnameAsDisplayName": 0,
     "allowGuestHandles": 0,
+    "allowAnonymousPosts": 0,
     "guestsIncrementTopicViews": 1,
     "allowGuestReplyNotifications": 1,
     "incrementTopicViewsInterval": 60,

--- a/public/language/en-GB/admin/settings/post.json
+++ b/public/language/en-GB/admin/settings/post.json
@@ -60,5 +60,7 @@
 	"backlinks.help": "If a post references another topic, a link back to the post will be inserted into the referenced topic at that point in time.",
 	"ip-tracking": "IP Tracking",
 	"ip-tracking.each-post": "Track IP Address for each post",
-	"enable-post-history": "Enable Post History"
+	"enable-post-history": "Enable Post History",
+	"allow-anonymous-posts": "Allow anonymous posting",
+	"allow-anonymous-posts-help": "When enabled, users will see a \"Post anonymously\" checkbox in the composer. Anonymous posts hide the author's identity."
 }

--- a/public/language/en-US/admin/settings/post.json
+++ b/public/language/en-US/admin/settings/post.json
@@ -60,5 +60,7 @@
 	"backlinks.help": "If a post references another topic, a link back to the post will be inserted into the referenced topic at that point in time.",
 	"ip-tracking": "IP Tracking",
 	"ip-tracking.each-post": "Track IP Address for each post",
-	"enable-post-history": "Enable Post History"
+	"enable-post-history": "Enable Post History",
+	"allow-anonymous-posts": "Allow anonymous posting",
+	"allow-anonymous-posts-help": "When enabled, users will see a \"Post anonymously\" checkbox in the composer. Anonymous posts hide the author's identity."
 }

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -118,6 +118,12 @@
 						[[admin/settings/post:restrictions.stale-help]]
 					</p>
 				</div>
+
+				<div class="form-check form-switch mb-3">
+					<input class="form-check-input" type="checkbox" id="allowAnonymousPosts" data-field="allowAnonymousPosts">
+					<label for="allowAnonymousPosts" class="form-check-label">[[admin/settings/post:allow-anonymous-posts]]</label>
+					<p class="form-text">[[admin/settings/post:allow-anonymous-posts-help]]</p>
+				</div>
 			</div>
 
 			<hr/>


### PR DESCRIPTION
## Changes (Issue #9)
- Added `allowAnonymousPosts` config flag to defaults.json (default: disabled)
- Added admin toggle in ACP → Settings → Posts → Posting Restrictions
- Added language strings for en-GB and en-US
- Admins can now globally enable/disable the anonymous posting feature

## Testing
1. Navigate to ACP → Settings → Posts
2. Scroll to "Posting Restrictions" section
3. Verify "Allow anonymous posting" toggle appears
4. Toggle ON/OFF and save
5. Verify setting persists after page reload

## Next Steps
- Issue #6 : Add database storage to persist anonymous flag with posts
- Issue #5 : Add "Post anonymously" checkbox to composer UI

## Related Issues
Resolves #9 

## Before

https://github.com/user-attachments/assets/badebb48-b45d-401e-8b42-ecfae487ee3b


## After

https://github.com/user-attachments/assets/c2b04a2b-0d3f-4161-8608-e7bf7b0cc8c6

