### PR TITLE
fix: loosen /plugin endpoint test

### DIFF
--- a/public/openapi/read/admin/extend/plugins.yaml
+++ b/public/openapi/read/admin/extend/plugins.yaml
@@ -269,7 +269,6 @@ get:
                         - name
                         - updated
                         - latest
-                        - url
                         - numInstalls
                         - isCompatible
                         - id


### PR DESCRIPTION
Loosens the `/api/admin/extend/plugins` endpoint constraints so the test actually passes